### PR TITLE
Add support for mouse pointer interaction introduced in iOS 13.4

### DIFF
--- a/Mini vMac/ViewController.h
+++ b/Mini vMac/ViewController.h
@@ -10,7 +10,12 @@
 #import "ScreenView.h"
 #import "KBKeyboardView.h"
 
+#ifdef __IPHONE_13_4
+API_AVAILABLE(ios(13.4))
+@interface ViewController : UIViewController <UIPointerInteractionDelegate, KBKeyboardViewDelegate>
+#else
 @interface ViewController : UIViewController <KBKeyboardViewDelegate>
+#endif
 
 @property (weak, nonatomic) IBOutlet ScreenView *screenView;
 @property (nonatomic, getter=isKeyboardVisible) BOOL keyboardVisible;

--- a/Mini vMac/ViewController.m
+++ b/Mini vMac/ViewController.m
@@ -45,7 +45,12 @@
         // NSLog(@"Interaction: x2: %hi, y2: %hi", (short)mouseLoc.h, (short)mouseLoc.v);
         [[AppDelegate sharedEmulator] setMouseX:mouseLoc.h Y:mouseLoc.v];
     }
-    return nil;
+    return defaultRegion;
+}
+
+- (UIPointerStyle *)pointerInteraction:(UIPointerInteraction *)interaction styleForRegion:(UIPointerRegion *)region {
+    return [UIPointerStyle hiddenPointerStyle];
+
 }
 #endif
 


### PR DESCRIPTION
When a mouse is connected to an iPad, the emulated mouse pointer will follow the iOS mouse pointer movements. Change is backward compatible to earlier iOS versions < 13.4 without mouse pointer support.

It makes the emulator much nicer to use with a mouse on an iPad.

Unfortunately I tried but couldn't yet find a way to hide the iOS mouse cursor so the two cursors are on-screen at the moment.

This has been tested working on iOS 13.4 and 13.3.1.